### PR TITLE
add payment url

### DIFF
--- a/FLS01/README.md
+++ b/FLS01/README.md
@@ -177,6 +177,7 @@ Response:
   "payment_option_id":1,
   "amount_sats" : 800000 ,
   "expires_on": "2023-09-20T00:25:11.123Z",
+  "payment_url": "https://providerDomain/?order-id=8ed13c2a-a8c6-4f0e-b43e-3fdbf1f094a6",
   "payment_info": {
     "
   }


### PR DESCRIPTION
I suggest that the broker can directly provide a URL at this point, under this URL the purchase can be completed. 

The URL can be optional.
We at DFX will work exclusively with this URL at the beginning and will not transmit any bank details via API, otherwise the legal risk is extremely high. 

