### PR TITLE
GET /verify with node id

### DIFF
--- a/FLS01/README.md
+++ b/FLS01/README.md
@@ -72,7 +72,7 @@ Request a token to be signed by the reciever node as proof of ownership
 
 Request:
 ```
-GET /verify
+GET /verify?node_pubkey=02765a281bd188e80a89e6ea5092dcb8ebaaa5c5da341e64327e3fadbadcbc686c
 ```
 Response:
 


### PR DESCRIPTION
If the wallet verification is to be used (optional) then the node id must be given from the beginning, i.e. directly at GET /verify